### PR TITLE
Add ability to specify which cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ Currently the following variables are supported:
  defaults to "Security group for testing Molecule"
 * `molecule_openstack_ci_security_group_rules` - Array of argument dictionaries passed to
  (os_security_group_rule)[https://docs.ansible.com/ansible/latest/modules/os_security_group_rule_module.html]
- module, defaults to `[{"ethertype": "IPv4"}, {"ethertype": "IPv6"}], effectively allowing
+ module, defaults to `[{"ethertype": "IPv4"}, {"ethertype": "IPv6"}]`, effectively allowing
  all access to molecule instances by default.
 * `molecule_openstack_ci_keypair_name` - molecule_key
 * `molecule_openstack_ci_security_group_name` - SSH keypair name prefix to use
  when generating keypair. Defaults to "molecule_key". The actual keypair
  created will have the run hash appended to its name.
+* `molecule_openstack_ci_cloud` - name of the OpenStack cloud to connect to. This defaults to being omitted,
+ in which case the openstack libraries will read the environment variable "OS\_CLOUD" by default. Set this
+ value if you want to override that for specific cases or do not have the value set.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ molecule_openstack_ci_security_group_rules:
 
 # run_hash will be appended to keypair name
 molecule_openstack_ci_keypair_name: molecule_key
+
+molecule_openstack_ci_cloud: "{{ omit }}"

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -9,3 +9,4 @@
     - name: molecule_openstack_ci
       vars:
         molecule_openstack_ci_state: present
+        molecule_openstack_ci_cloud: default

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -9,3 +9,4 @@
     - name: molecule_openstack_ci
       vars:
         molecule_openstack_ci_state: absent
+        molecule_openstack_ci_cloud: default

--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -2,12 +2,14 @@
 # "molecule init scenario -d openstack ..."
 - name: Create security group for scenario
   os_security_group:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ hashed_security_group_name }}"
     description: "{{ molecule_openstack_ci_security_group_description }}"
   register: security_group
 
 - name: Create security group rules
   os_security_group_rule:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     security_group: "{{ hashed_security_group_name }}"
     protocol: "{{ item.proto | default(omit) }}"
     port_range_min: "{{ item.port | default(omit) }}"
@@ -24,12 +26,14 @@
 
 - name: Delete remote keypair
   os_keypair:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ hashed_keypair_name }}"
     state: absent
   when: not keypair_local.stat.exists
 
 - name: Create keypair
   os_keypair:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ hashed_keypair_name }}"
   register: keypair
 
@@ -42,6 +46,7 @@
 
 - name: Create molecule instance(s)
   os_server:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ item.name }}-{{ run_hash }}"
     image: "{{ item.image }}"
     flavor: "{{ item.flavor }}"

--- a/tasks/destroy.yml
+++ b/tasks/destroy.yml
@@ -1,5 +1,6 @@
 - name: Destroy molecule instance(s)
   os_server:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ item.name }}-{{ run_hash }}"
     state: absent
   register: server
@@ -25,10 +26,12 @@
 
 - name: Delete security group
   os_security_group:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ hashed_security_group_name }}"
     state: absent
 
 - name: Delete remote keypair
   os_keypair:
+    cloud: "{{ molecule_openstack_ci_cloud }}"
     name: "{{ hashed_keypair_name }}"
     state: absent


### PR DESCRIPTION
Rather than relying on the environment variable OS_CLOUD, give the user
the ability to specify the name of a cloud to use. In the absence of
that value being specified, then fallback to the value of OS_CLOUD (or
whatever future default method openstacksdk and os-client-config use)