### PR TITLE
Add support for OpenStack VM volumes

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -44,6 +44,23 @@
     mode: 0600
   when: keypair.changed
 
+- name: Create molecule volume(s)
+  os_volume:
+    display_name: "{{ item.name }}"
+    size: "{{ item.size }}"
+  register: volume
+  with_items: "{{ molecule_yml.volumes }}"
+  async: 7200
+  poll: 0
+
+- name: Wait for volume(s) to complete
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: vol_jobs
+  until: vol_jobs is finished
+  retries: 300
+  with_items: "{{ volume.results }}"
+
 - name: Create molecule instance(s)
   os_server:
     cloud: "{{ molecule_openstack_ci_cloud }}"
@@ -52,6 +69,8 @@
     flavor: "{{ item.flavor }}"
     security_groups: "{{ hashed_security_group_name }}"
     key_name: "{{ hashed_keypair_name }}"
+    volumes: "{{ item.volumes | default(omit) }}"
+    delete_fip: true
     meta:
       # The generated inventory will still be using the instance name
       # as defined in molecule.yml. Stash the original name in the instance

--- a/tasks/destroy.yml
+++ b/tasks/destroy.yml
@@ -16,6 +16,12 @@
   retries: 300
   with_items: "{{ server.results }}"
 
+- name: Destroy molecule volume(s)
+  os_volume:
+    display_name: "{{ item.name }}"
+    state: absent
+  with_items: "{{ molecule_yml.volumes }}"
+
 # Mandatory configuration for Molecule to function.
 
 - name: Clear instance config


### PR DESCRIPTION
In the molecule.yml file, a top level field "volumes" can be created
that is an array of os_volume arguments, including name and size. These
resources will be created and destroyed just as the VMs are. Also, this
allows the enhancement of the creation of a VM with the "volumes"
field inside its definition dict.