### PR TITLE
Update role defaults like molecule_docker_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
-versions:
+python:
   - "2.7"
-  - "3.5"
+  - "3.7"
 cache: pip
-sudo: required
-services:
-  - docker
 
 install:
   - pip install -U pip

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Currently the following variables are supported:
 * `molecule_openstack_ci_security_group_name` - SSH keypair name prefix to use
  when generating keypair. Defaults to "molecule_key". The actual keypair
  created will have the run hash appended to its name.
-* `molecule_openstack_ci_cloud` - name of the OpenStack cloud to connect to. This defaults to being omitted,
- in which case the openstack libraries will read the environment variable "OS\_CLOUD" by default. Set this
- value if you want to override that for specific cases or do not have the value set.
+* `molecule_openstack_ci_cloud` - name of the OpenStack cloud to connect to. This defaults to the value
+ of the environment variable "`OS\_CLOUD`" if it is set, or "`default`" if not.
+* `molecule_openstack_ci_state` - Whether to create (`present`) or destroy (`absent`) molecule resources.
+ Defaults to `present`.
 
 Dependencies
 ------------
@@ -61,16 +62,10 @@ Molecule scenario `create.yml`:
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: |-
-    {{ not (lookup('env', 'MOLECULE_DEBUG') | bool or
-       molecule_yml.provisioner.log|default(false) | bool) }}
   roles:
-    - name: oasis_roles.molecule_openstack_ci
-      vars:
-        # this var is required for create and destroy
-        molecule_openstack_ci_state: present
-        # other vars can be set here, e.g.
-        # molecule_openstack_ci_ssh_user: yourcloudusername
+    - role: oasis_roles.molecule_openstack_ci
+      # other vars can be set here, e.g.
+      # molecule_openstack_ci_ssh_user: yourcloudusername
 ```
 
 Molecule scenario `destroy.yml`:
@@ -79,22 +74,13 @@ Molecule scenario `destroy.yml`:
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: |-
-    {{ not (lookup('env', 'MOLECULE_DEBUG') | bool or
-       molecule_yml.provisioner.log|default(false) | bool) }}
   roles:
-    - name: oasis_roles.molecule_openstack_ci
-      vars:
-        molecule_openstack_ci_state: absent
+    - role: oasis_roles.molecule_openstack_ci
+      molecule_openstack_ci_state: absent
 ```
 
-**Note:** Remember to add "oasis_roles.molecule_openstack_ci" to your
+**Note:** Remember to add `oasis_roles.molecule_openstack_ci` to your
 molecule scenario dependencies.
-
-Molecule scenario `requirements.yml`:
-```yaml
-- name: oasis_roles.molecule_openstack_ci
-```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,6 @@ molecule_openstack_ci_security_group_rules:
 # run_hash will be appended to keypair name
 molecule_openstack_ci_keypair_name: molecule_key
 
-molecule_openstack_ci_cloud: "{{ omit }}"
+molecule_openstack_ci_cloud: >-
+  {{ lookup('env', 'OS_CLOUD') | default('default', true) }}
+molecule_openstack_ci_state: present

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -3,7 +3,4 @@
   connection: local
   gather_facts: false
   roles:
-    - name: molecule_openstack_ci
-      vars:
-        molecule_openstack_ci_state: present
-        molecule_openstack_ci_cloud: default
+    - role: molecule_openstack_ci

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -3,7 +3,5 @@
   connection: local
   gather_facts: false
   roles:
-    - name: molecule_openstack_ci
-      vars:
-        molecule_openstack_ci_state: absent
-        molecule_openstack_ci_cloud: default
+    - role: molecule_openstack_ci
+      molecule_openstack_ci_state: absent


### PR DESCRIPTION
These updates are inspired by simplifications and improvements seen in
the molecule_docker_ci OASIS role, such as defaulting to the 'present'
state, and providing a reasonable default cloud name instead of default
to `omit`.

README examples were also updated with the more concise role invocation
found in molecule_docker_ci's README.